### PR TITLE
Menu block already open

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,3 +1,5 @@
+local MenuOpen = false
+
 RegisterNUICallback("dataPost", function(data, cb)
     SetNuiFocus(false)
     TriggerEvent(data.event, data.args)
@@ -11,9 +13,15 @@ end)
 
 RegisterNetEvent('nh-context:sendMenu', function(data)
     if not data then return end
-    SetNuiFocus(true, true)
-    SendNUIMessage({
-        action = "OPEN_MENU",
-        data = data
-    })
+    if not MenuOpen then
+        SetNuiFocus(true, true)
+        MenuOpen = true
+        SendNUIMessage({
+            action = "OPEN_MENU",
+            data = data
+        })
+    else
+        print('A menu is already open to do this action')
+    end
 end)
+


### PR DESCRIPTION
Menu close when the player or script tries to open a menu when it already has one open. The current open menu will not be affected