### PR TITLE
Server var reset and menu open fix

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -4,6 +4,7 @@ RegisterNUICallback("dataPost", function(data, cb)
     SetNuiFocus(false)
     if server then
         TriggerServerEvent(data.event, data.args)
+        server = false
     else
         TriggerEvent(data.event, data.args)
     end

--- a/client.lua
+++ b/client.lua
@@ -9,6 +9,7 @@ RegisterNUICallback("dataPost", function(data, cb)
     else
         TriggerEvent(data.event, data.args)
     end
+    menuOpen = false
     cb('ok')
 end)
 


### PR DESCRIPTION
`line 8` set server = false in the server event to prevent the state overriding the client.lua server = false state. 

`lines 2 & 12 & 26` added menuOpen variable. prevents opening another menu of the same type and sets it back to false so a new menu may be opened again.